### PR TITLE
PHP 8 Deprecation Warnings

### DIFF
--- a/Classes/PHPExcel/Shared/Drawing.php
+++ b/Classes/PHPExcel/Shared/Drawing.php
@@ -70,7 +70,7 @@ class PHPExcel_Shared_Drawing
      * @param     PHPExcel_Style_Font $pDefaultFont    Default font of the workbook
      * @return     int            Value in cell dimension
      */
-    public static function pixelsToCellDimension($pValue = 0, PHPExcel_Style_Font $pDefaultFont)
+    public static function pixelsToCellDimension($pValue, PHPExcel_Style_Font $pDefaultFont) // Owen 20200917 remove default
     {
         // Font name and size
         $name = $pDefaultFont->getName();
@@ -95,7 +95,7 @@ class PHPExcel_Shared_Drawing
      * @param     PHPExcel_Style_Font $pDefaultFont    Default font of the workbook
      * @return     int        Value in pixels
      */
-    public static function cellDimensionToPixels($pValue = 0, PHPExcel_Style_Font $pDefaultFont)
+    public static function cellDimensionToPixels($pValue, PHPExcel_Style_Font $pDefaultFont) // Owen 20200917 remove default
     {
         // Font name and size
         $name = $pDefaultFont->getName();

--- a/Classes/PHPExcel/Worksheet.php
+++ b/Classes/PHPExcel/Worksheet.php
@@ -1468,13 +1468,14 @@ class PHPExcel_Worksheet implements PHPExcel_IComparable
     }
 
     /**
-     * Set conditional styles
+     * Set conditional styles.
      *
-     * @param $pCoordinate string E.g. 'A1'
-     * @param $pValue PHPExcel_Style_Conditional[]
-     * @return PHPExcel_Worksheet
+     * @param string $pCoordinate eg: 'A1'
+     * @param PHPExcel_Style_Conditional[] $pValue
+     *
+     * @return Worksheet
      */
-    public function setConditionalStyles($pCoordinate = 'A1', $pValue)
+    public function setConditionalStyles($pCoordinate, $pValue) // Owen 20200917 change Docblock remove default
     {
         $this->conditionalStylesCollection[strtoupper($pCoordinate)] = $pValue;
         return $this;

--- a/Classes/PHPExcel/Writer/Excel2007/Chart.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Chart.php
@@ -1257,7 +1257,7 @@ class PHPExcel_Writer_Excel2007_Chart extends PHPExcel_Writer_Excel2007_WriterPa
      *
      * @throws  PHPExcel_Writer_Exception
      */
-    private function writePlotSeriesValues($plotSeriesValues, $objWriter, $groupType, $dataType = 'str', PHPExcel_Worksheet $pSheet)
+    private function writePlotSeriesValues($plotSeriesValues, $objWriter, $groupType, $dataType, PHPExcel_Worksheet $pSheet) // Owen 20200917 remove default dataType
     {
         if (is_null($plotSeriesValues)) {
             return;


### PR DESCRIPTION
4 instances of parameter with default coming
before parameter without default.
Removed default in all cases.