### PR TITLE
Error in ReferenceHelper columnReverseSort

### DIFF
--- a/Classes/PHPExcel/Calculation/TextData.php
+++ b/Classes/PHPExcel/Calculation/TextData.php
@@ -509,7 +509,7 @@ class PHPExcel_Calculation_TextData
      * @param    string    $newText    String to replace in defined position
      * @return    string
      */
-    public static function REPLACE($oldText = '', $start = 1, $chars = null, $newText)
+    public static function REPLACE($oldText = '', $start = 1, $chars = null, $newText = '') // Owen 20200919 PHP 8 Deprecation guess default for newText
     {
         $oldText = PHPExcel_Calculation_Functions::flattenSingleValue($oldText);
         $start   = PHPExcel_Calculation_Functions::flattenSingleValue($start);

--- a/Classes/PHPExcel/NamedRange.php
+++ b/Classes/PHPExcel/NamedRange.php
@@ -72,7 +72,7 @@ class PHPExcel_NamedRange
      * @param PHPExcel_Worksheet|null $pScope    Scope. Only applies when $pLocalOnly = true. Null for global scope.
      * @throws PHPExcel_Exception
      */
-    public function __construct($pName = null, PHPExcel_Worksheet $pWorksheet, $pRange = 'A1', $pLocalOnly = false, $pScope = null)
+    public function __construct($pName, PHPExcel_Worksheet $pWorksheet, $pRange = 'A1', $pLocalOnly = false, $pScope = null) // Owen 20200919 PHP 8 Deprecation remove default for pName
     {
         // Validate data
         if (($pName === null) || ($pWorksheet === null) || ($pRange === null)) {
@@ -227,7 +227,7 @@ class PHPExcel_NamedRange
      * @param PHPExcel_Worksheet|null $pSheet Scope. Use null for global scope
      * @return PHPExcel_NamedRange
      */
-    public static function resolveRange($pNamedRange = '', PHPExcel_Worksheet $pSheet)
+    public static function resolveRange($pNamedRange, PHPExcel_Worksheet $pSheet) // Owen 20200919 PHP 8 Deprecation remove default for pNamedRange
     {
         return $pSheet->getParent()->getNamedRange($pNamedRange, $pSheet);
     }

--- a/Classes/PHPExcel/ReferenceHelper.php
+++ b/Classes/PHPExcel/ReferenceHelper.php
@@ -85,7 +85,7 @@ class PHPExcel_ReferenceHelper
      */
     public static function columnReverseSort($a, $b)
     {
-        return 1 - strcasecmp(strlen($a) . $a, strlen($b) . $b);
+        return -strcasecmp(strlen($a) . $a, strlen($b) . $b); // Owen 20200919 breaks in PHP8 needs to be propagated to PhpSpreadsheet
     }
 
     /**

--- a/Classes/PHPExcel/Writer/Excel5/Workbook.php
+++ b/Classes/PHPExcel/Writer/Excel5/Workbook.php
@@ -830,7 +830,7 @@ class PHPExcel_Writer_Excel5_Workbook extends PHPExcel_Writer_Excel5_BIFFwriter
      * @param    boolean      $isHidden
      * @return    string    Complete binary record data
      * */
-    private function writeShortNameBiff8($name, $sheetIndex = 0, $rangeBounds, $isHidden = false)
+    private function writeShortNameBiff8($name, $sheetIndex, $rangeBounds, $isHidden = false) // Owen 20200919 PHP 8 Deprecation remove default for name
     {
         $record = 0x0018;
 


### PR DESCRIPTION
Logic is wrong in both PHPExcel and PhpSpreadsheet.
Function should return -strcasecmp, not 1 - strcasecmp.
Error showed up in Php8 testing.

Also tack on 3 modules with Php8 deprecation corrections.