### PR TITLE
Permanent Fix Eliminating Annual Test Changes

### DIFF
--- a/unitTests/Classes/PHPExcel/Calculation/DateTimeTest.php
+++ b/unitTests/Classes/PHPExcel/Calculation/DateTimeTest.php
@@ -98,6 +98,28 @@ class DateTimeTest extends PHPUnit_Framework_TestCase
         return new testDataFileIterator('rawTestData/Calculation/DateTime/DATEVALUE.data');
     }
 
+    /**
+     * @dataProvider providerDATEVALUE2
+     */
+    public function testDATEVALUE2()
+    {
+        $args = func_get_args();
+        $curryear = date('Y');
+        $expectedResult = $curryear . array_pop($args);
+        $expectedResult = call_user_func_array(array('PHPExcel_Calculation_DateTime', 'DATEVALUE'), array($expectedResult));
+        $result = call_user_func_array(array('PHPExcel_Calculation_DateTime', 'DATEVALUE'), $args);
+        if (method_exists($this, 'assertEqualsWithDelta')) {
+            $this->assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        } else {
+            $this->assertEquals($expectedResult, $result, null, 1E-8);
+        }
+    }
+
+    public function providerDATEVALUE2()
+    {
+        return new testDataFileIterator('rawTestData/Calculation/DateTime/DATEVALUE2.data');
+    }
+
     public function testDATEVALUEtoPHP()
     {
         PHPExcel_Calculation_Functions::setReturnDateType(PHPExcel_Calculation_Functions::RETURNDATE_PHP_NUMERIC);

--- a/unitTests/rawTestData/Calculation/DateTime/DATEVALUE.data
+++ b/unitTests/rawTestData/Calculation/DateTime/DATEVALUE.data
@@ -35,12 +35,6 @@
 "22 August 98",			36029
 "1st March 2007",		39142		//	MS Excel will fail with a #VALUE return, but PHPExcel can parse this date
 "The 1st day of March 2007",	"#VALUE!"
-# Owen The following 5 tests need to be adjusted year by year - valid for 2019
-"1 Jan",			44197 // set for 2021
-"31/12",			44561 // set for 2021
-"12/31",			44561 // set for 2021		//	might depend on regional settings - Excel reads as 1st December 1931, not 31st December in current year
-"5-JUL",			44382 // set for 2021
-"5 Jul",			44382 // set for 2021
 "12/2008",			39783
 "10/32",			11963
 11,				"#VALUE!"

--- a/unitTests/rawTestData/Calculation/DateTime/DATEVALUE2.data
+++ b/unitTests/rawTestData/Calculation/DateTime/DATEVALUE2.data
@@ -1,0 +1,6 @@
+# Date String			-MM-DD (year will be treated as current year)
+"1 Jan",			"-01-01"
+"31/12",			"-12-31"
+"12/31",			"-12-31"		//	might depend on regional settings - Excel reads as 1st December 1931, not 31st December in current year
+"5-JUL",			"-07-05"
+"5 Jul",			"-07-05"


### PR DESCRIPTION
Tests of DATEVALUE using implicit, i.e. current, year
needed to be changed every year.
This change isolates those tests into new test and data,
and no longer need to be changed each year.